### PR TITLE
fix(ci): calibrate coverage floor to unit-test-only matrix (35%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ First Production/Stable release. PyPI classifier flipped to `Development Status 
 
 ### Changed
 
-- `[tool.coverage.report] fail_under` raised from `24` to `55` to prevent silent regression. Actual coverage on `main` post-fix: ~59% (`pytest --cov` 2026-05-10). PRD NFR-6's 80% target re-anchored to v1.1 milestone (server module test coverage).
+- `[tool.coverage.report] fail_under` raised from `24` to `35`, calibrated to the
+  unit-test-only CI matrix (CI runs `pytest --cov --ignore=tests/integration/` per
+  `.github/workflows/ci.yml`, yielding ~37% coverage). Locally with integration
+  tests included, coverage rises to ~59%. Staged-floor path: 24 → 35 (v1.0.0)
+  → 55 (v1.0.1, after wiring `tests/integration/` into CI) → 80 (v1.1, after
+  `riskforge.server` unit tests). PRD NFR-6's 80% target re-anchored to v1.1.
 - `pyproject.toml` Documentation URL updated from `github.com/aiexponenthq/riskforge#readme` → `aiexponent.com/docs/riskforge`.
 - `riskforge tests` Typer help text aligned to Article 9(6)–(8) (was "9(7)" only).
 - `LICENSE` replaced with the verbatim Apache-2.0 SPDX template (canonical from apache.org). Earlier file had material text drift in §8 and was missing the Appendix template — caused GitHub to surface "NOASSERTION" instead of "Apache-2.0". `NOTICE` file added per Apache 2.0 §4(d) for the AI Exponent LLC copyright attribution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,14 @@ source = ["riskforge"]
 branch = true
 
 [tool.coverage.report]
-# v1.0 floor pragmatically set at 55%. PRD NFR-6 (line 375) targets ≥80%; the gap
-# is concentrated in the optional `riskforge.server` API surface (~0% coverage)
-# and is re-anchored to the v1.1 milestone — see CHANGELOG [Unreleased] note.
-# Raising in two steps: 24 → 55 (this release) → 80 (v1.1) prevents silent regression
-# without blocking GA on test-writing for the optional server module.
-fail_under = 55
+# v1.0 floor set at 35%, calibrated to the unit-test-only CI matrix. CI runs
+# `pytest --cov --ignore=tests/integration/` (see .github/workflows/ci.yml line 57),
+# which exercises engine/, models/, storage/, the boundary tests, and the contract
+# tests but does NOT run the integration tests that exercise the CLI commands or
+# server modules. Locally with integration tests included, coverage rises to ~59%.
+#
+# Raising path: 24 → 35 (this release) → 55 (v1.0.1, after `tests/integration/`
+# is wired into CI) → 80 (v1.1, after server module unit tests). This staged
+# approach prevents silent regression at each milestone without blocking GA on
+# CI infrastructure work.
+fail_under = 35


### PR DESCRIPTION
## Summary

CI failed on the v1.0.0 release PR (`#4`) with:
> `Required test coverage of 55.0% not reached. Total coverage: 36.81%`

Root cause: in PR #4 I set `fail_under = 55` based on **local** coverage (which includes `tests/integration/`). CI runs `pytest --cov --ignore=tests/integration/` per `.github/workflows/ci.yml:57`, which yields **37%** because the integration tests exercise the CLI commands (~404 statements at 0% in the unit-test-only run).

## Fix

`fail_under: 55 → 35` in `pyproject.toml`, with a comment + CHANGELOG entry documenting the staged-floor path:

| Floor | Milestone | Trigger |
|---|---|---|
| 24 | (prior) | — |
| **35** | **v1.0.0 (this PR)** | tracks the unit-test-only CI matrix honestly |
| 55 | v1.0.1 | wire `tests/integration/` into CI as a separate job |
| 80 | v1.1 | add `riskforge.server` unit tests |

PRD NFR-6's 80% target stays re-anchored to v1.1.

## Verification

```
$ pytest tests/ --ignore=tests/integration --cov --cov-report=term --quiet
TOTAL  1481  905  228  17  37%
Required test coverage of 35.0% reached. Total coverage: 36.81%
52 passed in 0.67s
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the v1.0.0 tag goes up and `release.yml` fires